### PR TITLE
[KRK-1823]: Introduce catalog-info.yaml

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,14 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: go-pingdom
+  description: go-pingdom is a Go client library for the Pingdom API.
+  annotations:
+    contentful.com/service-tier: "4"
+    github.com/project-slug: contentful/go-pingdom
+    circleci.com/project-slug: github/contentful/go-pingdom
+spec:
+  type: library
+  owner: group:team-kraken
+  lifecycle: production
+  system: content-rds


### PR DESCRIPTION
Added catalog-info.yaml to the go-pingdom repo to ensure it's recognized as actively maintained and owned by Team Kraken. This file defines the library's metadata, ownership, and lifecycle, preventing it from being archived.


```
apiVersion: backstage.io/v1alpha1
kind: Component
metadata:
  name: go-pingdom
  description: go-pingdom is a Go client library for the Pingdom API.
  annotations:
    contentful.com/service-tier: "4"
    github.com/project-slug: contentful/go-pingdom
    circleci.com/project-slug: github/contentful/go-pingdom
spec:
  type: library
  owner: group:team-kraken
  lifecycle: production
  system: content-rds
  ```